### PR TITLE
:camera_flash: Download one raw transition per program

### DIFF
--- a/bin/data/shankari@eecs.berkeley.edu/train_bus_ebike_mtv_ucb/config~evaluation_spec/0_9223372036854775807.json
+++ b/bin/data/shankari@eecs.berkeley.edu/train_bus_ebike_mtv_ucb/config~evaluation_spec/0_9223372036854775807.json
@@ -1,11 +1,11 @@
 {
     "_id": {
-        "$oid": "60406b111fa22fb602d0a822"
+        "$oid": "63ddfe5eea54a12d2808de51"
     },
     "metadata": {
         "key": "config/evaluation_spec",
         "platform": "script",
-        "write_ts": 1614834449.811379,
+        "write_ts": 1675492947.4768698,
         "time_zone": "America/Los_Angeles",
         "type": "message"
     },
@@ -18160,6 +18160,6 @@
                 ]
             }
         },
-        "write_ts": 1614834449.811379
+        "write_ts": 1675492947.4768698
     }
 }

--- a/bin/data/ucb-sdb-android-1/car_scooter_brex_san_jose/statemachine~transition/1563821438_1563846249.json
+++ b/bin/data/ucb-sdb-android-1/car_scooter_brex_san_jose/statemachine~transition/1563821438_1563846249.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3622b5b88f219ca090b955"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1563821438.421
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1563821438.42,
+            "write_ts": 1563821438.421
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/car_scooter_brex_san_jose/statemachine~transition/1565116007_1565140214.json
+++ b/bin/data/ucb-sdb-android-1/car_scooter_brex_san_jose/statemachine~transition/1565116007_1565140214.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d49e4aeb88f219ca0bf5676"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565116007.762
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1565116007.762,
+            "write_ts": 1565116007.762
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/car_scooter_brex_san_jose/statemachine~transition/1565194658_1565217817.json
+++ b/bin/data/ucb-sdb-android-1/car_scooter_brex_san_jose/statemachine~transition/1565194658_1565217817.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d4b17f9b88f219ca0c1fb4c"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565194658.305
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1565194658.304,
+            "write_ts": 1565194658.305
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/car_scooter_brex_san_jose/statemachine~transition/1583349554_1583372564.json
+++ b/bin/data/ucb-sdb-android-1/car_scooter_brex_san_jose/statemachine~transition/1583349554_1583372564.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5e601ac722ab29840bfdaf4d"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1583349554.743
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1583349554.742,
+            "write_ts": 1583349554.743
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560463523_1560525050.json
+++ b/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560463523_1560525050.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d02d8e3b88f219ca0543d56"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560463525.24
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560463525.239,
+            "write_ts": 1560463525.24
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560538052_1560603684.json
+++ b/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560538052_1560603684.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d040820b88f219ca056102a"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560538053.695
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560538053.694,
+            "write_ts": 1560538053.695
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560665721_1560722362.json
+++ b/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560665721_1560722362.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d05e8fdb88f219ca0589d39"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560665722.227
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560665722.225,
+            "write_ts": 1560665722.227
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560742839_1560795491.json
+++ b/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560742839_1560795491.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d071042b88f219ca05a4375"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560742841.15
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560742841.149,
+            "write_ts": 1560742841.15
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560872200_1560915075.json
+++ b/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560872200_1560915075.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d090a81b88f219ca05bbb56"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560872201.345
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560872201.345,
+            "write_ts": 1560872201.345
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560923342_1560966141.json
+++ b/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1560923342_1560966141.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d0a0562b88f219ca05d08a7"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560923343.375
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560923343.374,
+            "write_ts": 1560923343.375
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1564291253_1564322510.json
+++ b/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1564291253_1564322510.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3d3574b88f219ca0a66e9a"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564291253.452
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564291253.451,
+            "write_ts": 1564291253.452
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1564378191_1564431525.json
+++ b/bin/data/ucb-sdb-android-1/sfba_hf_calibration_stationary_only/statemachine~transition/1564378191_1564431525.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3e86f6b88f219ca0aa45a9"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564378192.027
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564378192.026,
+            "write_ts": 1564378192.027
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563944815_1563973554.json
+++ b/bin/data/ucb-sdb-android-1/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563944815_1563973554.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d37ef74b88f219ca095e72d"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1563944816.083
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1563944816.082,
+            "write_ts": 1563944816.083
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_med_freq_calibration_stationary_only/statemachine~transition/1565459507_1565497157.json
+++ b/bin/data/ucb-sdb-android-1/sfba_med_freq_calibration_stationary_only/statemachine~transition/1565459507_1565497157.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d4f1ea7b88f219ca0c87e3d"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565459507.826
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1565459507.825,
+            "write_ts": 1565459507.826
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/sfba_med_freq_calibration_stationary_only/statemachine~transition/1566326171_1566365177.json
+++ b/bin/data/ucb-sdb-android-1/sfba_med_freq_calibration_stationary_only/statemachine~transition/1566326171_1566365177.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d5c5785b88f219ca0d5d41f"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1566326172.008
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1566326172.008,
+            "write_ts": 1566326172.008
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1568128283_1568171424.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1568128283_1568171424.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d77d238b88f219ca0fe5c03"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1568128283.665
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1568128283.663,
+            "write_ts": 1568128283.665
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1568214664_1568259368.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1568214664_1568259368.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d7915c9b88f219ca0033d6a"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1568214664.905
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1568214664.905,
+            "write_ts": 1568214664.905
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1568732827_1568775433.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1568732827_1568775433.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d811469b88f219ca0105f7d"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1568732827.26
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1568732827.259,
+            "write_ts": 1568732827.26
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1574179702_1574222117.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1574179702_1574222117.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5dd4209522ab29840bc89c4a"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1574179702.254
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1574179702.253,
+            "write_ts": 1574179702.254
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1574266175_1574308931.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1574266175_1574308931.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5dd56d4122ab29840bca62dc"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1574266175.37
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1574266175.369,
+            "write_ts": 1574266175.37
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1575389661_1575432801.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1575389661_1575432801.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5de69c4222ab29840bd10a31"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1575389662.049
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1575389662.048,
+            "write_ts": 1575389662.049
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1575907983_1575951083.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1575907983_1575951083.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5dee956c22ab29840bd4eb3b"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1575907983.83
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1575907983.829,
+            "write_ts": 1575907983.83
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1576080703_1576123736.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1576080703_1576123736.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5df12a8d22ab29840bd75e3f"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1576080703.214
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1576080703.213,
+            "write_ts": 1576080703.214
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1581005619_1581048110.json
+++ b/bin/data/ucb-sdb-android-1/train_bus_ebike_mtv_ucb/statemachine~transition/1581005619_1581048110.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5e3c5ddb22ab29840bf15629"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1581005619.292
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1581005619.291,
+            "write_ts": 1581005619.292
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/unimodal_trip_car_bike_mtv_la/statemachine~transition/1564274314_1564282394.json
+++ b/bin/data/ucb-sdb-android-1/unimodal_trip_car_bike_mtv_la/statemachine~transition/1564274314_1564282394.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3d059eb88f219ca0a5bd60"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564274314.853
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564274314.852,
+            "write_ts": 1564274314.853
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-1/unimodal_trip_car_bike_mtv_la/statemachine~transition/1567288614_1567297341.json
+++ b/bin/data/ucb-sdb-android-1/unimodal_trip_car_bike_mtv_la/statemachine~transition/1567288614_1567297341.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d6b05a1b88f219ca0ec0513"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1567288614.805
+        },
+        "user_id": {
+            "$uuid": "6a2dbafdef1e404cb61e506b8935dca4"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1567288614.804,
+            "write_ts": 1567288614.805
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560463541_1560525163.json
+++ b/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560463541_1560525163.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d02e5e6b88f219ca054662a"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560463542.915
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560463542.913,
+            "write_ts": 1560463542.915
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560538079_1560603727.json
+++ b/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560538079_1560603727.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d03eeb5b88f219ca055b096"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560538080.881
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560538080.88,
+            "write_ts": 1560538080.881
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560665749_1560722409.json
+++ b/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560665749_1560722409.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d05e8f7b88f219ca0588862"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560665750.243
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560665750.242,
+            "write_ts": 1560665750.243
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560742867_1560795517.json
+++ b/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560742867_1560795517.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d071040b88f219ca05a4327"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560742868.941
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560742868.94,
+            "write_ts": 1560742868.941
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560804506_1560845915.json
+++ b/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560804506_1560845915.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d07ff53b88f219ca05b031e"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560804507.335
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560804507.334,
+            "write_ts": 1560804507.335
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560872225_1560915091.json
+++ b/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1560872225_1560915091.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d09ac93b88f219ca05cb0cc"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560872227.212
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560872227.21,
+            "write_ts": 1560872227.212
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1564291261_1564322535.json
+++ b/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1564291261_1564322535.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3d3a78b88f219ca0a67635"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564291261.614
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564291261.613,
+            "write_ts": 1564291261.614
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1564378202_1564431536.json
+++ b/bin/data/ucb-sdb-android-2/sfba_hf_calibration_stationary_only/statemachine~transition/1564378202_1564431536.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3e8bf8b88f219ca0aa4de4"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564378202.385
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564378202.384,
+            "write_ts": 1564378202.385
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563944837_1563973570.json
+++ b/bin/data/ucb-sdb-android-2/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563944837_1563973570.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d37f478b88f219ca095ea77"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1563944837.242
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1563944837.241,
+            "write_ts": 1563944837.242
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_med_freq_calibration_stationary_only/statemachine~transition/1565459518_1565497183.json
+++ b/bin/data/ucb-sdb-android-2/sfba_med_freq_calibration_stationary_only/statemachine~transition/1565459518_1565497183.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d4f20b6b88f219ca0c8818e"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565459518.934
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1565459518.933,
+            "write_ts": 1565459518.934
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-2/sfba_med_freq_calibration_stationary_only/statemachine~transition/1566326188_1566365200.json
+++ b/bin/data/ucb-sdb-android-2/sfba_med_freq_calibration_stationary_only/statemachine~transition/1566326188_1566365200.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d5c74d2b88f219ca0d5e1fb"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1566326189.048
+        },
+        "user_id": {
+            "$uuid": "1377b14507144a139a1edbc0dcd6fafe"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1566326189.048,
+            "write_ts": 1566326189.048
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560405245_1560453851.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560405245_1560453851.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d01ea0bb88f219ca05300c7"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560405247.093
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560405247.092,
+            "write_ts": 1560405247.093
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560463576_1560525128.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560463576_1560525128.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d02e93fb88f219ca0548ac4"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560463578.076
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560463578.075,
+            "write_ts": 1560463578.076
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560538099_1560603758.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560538099_1560603758.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d03eeb4b88f219ca055a954"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560538101.191
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560538101.189,
+            "write_ts": 1560538101.191
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560665775_1560722456.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560665775_1560722456.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d06b2f9b88f219ca059733f"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560665776.643
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560665776.642,
+            "write_ts": 1560665776.643
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560742889_1560795532.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560742889_1560795532.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d071043b88f219ca05a43b2"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560742890.389
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560742890.388,
+            "write_ts": 1560742890.389
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560804526_1560845963.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560804526_1560845963.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d0832b2b88f219ca05b2e5c"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560804528.08
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560804528.079,
+            "write_ts": 1560804528.08
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560872251_1560915106.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560872251_1560915106.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d090a8eb88f219ca05bc4e9"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560872252.743
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560872252.742,
+            "write_ts": 1560872252.743
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560923383_1560966141.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1560923383_1560966141.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d0a7415b88f219ca05d886e"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560923384.9
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560923384.899,
+            "write_ts": 1560923384.9
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1564291272_1564322584.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1564291272_1564322584.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3d39e9b88f219ca0a674a9"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564291272.551
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564291272.55,
+            "write_ts": 1564291272.551
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1564378215_1564431563.json
+++ b/bin/data/ucb-sdb-android-3/sfba_hf_calibration_stationary_only/statemachine~transition/1564378215_1564431563.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3e8b62b88f219ca0aa4cde"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564378215.329
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564378215.328,
+            "write_ts": 1564378215.329
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563944862_1563973600.json
+++ b/bin/data/ucb-sdb-android-3/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563944862_1563973600.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d37f3e2b88f219ca095e8d8"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1563944863.095
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1563944863.094,
+            "write_ts": 1563944863.095
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_med_freq_calibration_stationary_only/statemachine~transition/1565459530_1565497201.json
+++ b/bin/data/ucb-sdb-android-3/sfba_med_freq_calibration_stationary_only/statemachine~transition/1565459530_1565497201.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d4f0623b88f219ca0c861d1"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565459530.217
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1565459530.216,
+            "write_ts": 1565459530.217
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-3/sfba_med_freq_calibration_stationary_only/statemachine~transition/1566326206_1566365227.json
+++ b/bin/data/ucb-sdb-android-3/sfba_med_freq_calibration_stationary_only/statemachine~transition/1566326206_1566365227.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d5c5a10b88f219ca0d5d5d5"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1566326206.634
+        },
+        "user_id": {
+            "$uuid": "34d4e435ae5b429f8f5e7f27a3bfa8cf"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1566326206.633,
+            "write_ts": 1566326206.634
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1563821473_1563846367.json
+++ b/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1563821473_1563846367.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3607b3b88f219ca0907dce"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1563821474.031
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1563821474.03,
+            "write_ts": 1563821474.031
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1564244116_1564263955.json
+++ b/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1564244116_1564263955.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3c8347b88f219ca0a32ec2"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564244116.278
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1564244116.277,
+            "write_ts": 1564244116.278
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1565026039_1565050298.json
+++ b/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1565026039_1565050298.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d486ed6b88f219ca0bc5b9d"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565026039.577
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1565026039.576,
+            "write_ts": 1565026039.577
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1565116073_1565140326.json
+++ b/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1565116073_1565140326.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d49e49eb88f219ca0bf5644"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565116073.967
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1565116073.966,
+            "write_ts": 1565116073.967
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1565194628_1565217932.json
+++ b/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1565194628_1565217932.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d4b171fb88f219ca0c1facc"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565194628.73
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1565194628.729,
+            "write_ts": 1565194628.73
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1583349589_1583372692.json
+++ b/bin/data/ucb-sdb-android-4/car_scooter_brex_san_jose/statemachine~transition/1583349589_1583372692.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5e60170422ab29840bfdae6a"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1583349589.571
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1583349589.57,
+            "write_ts": 1583349589.571
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560538133_1560603781.json
+++ b/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560538133_1560603781.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d03eeb0b88f219ca055a203"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560538134.728
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560538134.727,
+            "write_ts": 1560538134.728
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560665801_1560722494.json
+++ b/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560665801_1560722494.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d05e8f3b88f219ca0586fd2"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560665802.224
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560665802.223,
+            "write_ts": 1560665802.224
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560742920_1560795552.json
+++ b/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560742920_1560795552.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d07103db88f219ca05a42eb"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560742921.564
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560742921.563,
+            "write_ts": 1560742921.564
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560804550_1560845983.json
+++ b/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560804550_1560845983.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d07ff51b88f219ca05b018a"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560804551.405
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560804551.405,
+            "write_ts": 1560804551.405
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560872269_1560915128.json
+++ b/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1560872269_1560915128.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d093cabb88f219ca05c12b7"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1560872271.216
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1560872271.215,
+            "write_ts": 1560872271.216
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1564291280_1564322620.json
+++ b/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1564291280_1564322620.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3d3a16b88f219ca0a67575"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564291280.793
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564291280.792,
+            "write_ts": 1564291280.793
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1564378227_1564431578.json
+++ b/bin/data/ucb-sdb-android-4/sfba_hf_calibration_stationary_only/statemachine~transition/1564378227_1564431578.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3e8b97b88f219ca0aa4d3b"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564378227.847
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1564378227.846,
+            "write_ts": 1564378227.847
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563863286_1563890221.json
+++ b/bin/data/ucb-sdb-android-4/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563863286_1563890221.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d36b072b88f219ca0925f1c"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1563863287.049
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1563863287.048,
+            "write_ts": 1563863287.049
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563944882_1563973624.json
+++ b/bin/data/ucb-sdb-android-4/sfba_med_freq_calibration_stationary_only/statemachine~transition/1563944882_1563973624.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d37f41fb88f219ca095ea0c"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1563944882.461
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1563944882.46,
+            "write_ts": 1563944882.461
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_med_freq_calibration_stationary_only/statemachine~transition/1565459546_1565497218.json
+++ b/bin/data/ucb-sdb-android-4/sfba_med_freq_calibration_stationary_only/statemachine~transition/1565459546_1565497218.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d4f20ddb88f219ca0c882d7"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1565459547.036
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1565459547.035,
+            "write_ts": 1565459547.036
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/sfba_med_freq_calibration_stationary_only/statemachine~transition/1566326223_1566365245.json
+++ b/bin/data/ucb-sdb-android-4/sfba_med_freq_calibration_stationary_only/statemachine~transition/1566326223_1566365245.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d5c5964b88f219ca0d5d530"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1566326223.405
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.start_tracking",
+            "ts": 1566326223.404,
+            "write_ts": 1566326223.405
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1564153847_1564198715.json
+++ b/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1564153847_1564198715.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3b23b9b88f219ca09ebe26"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564153847.724
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1564153847.722,
+            "write_ts": 1564153847.724
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1568128311_1568171495.json
+++ b/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1568128311_1568171495.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d77c8b7b88f219ca0fe5795"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1568128311.721
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1568128311.72,
+            "write_ts": 1568128311.721
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1568214707_1568259423.json
+++ b/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1568214707_1568259423.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d791a38b88f219ca0035738"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1568214708.033
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1568214708.032,
+            "write_ts": 1568214708.033
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1568732860_1568775490.json
+++ b/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1568732860_1568775490.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d8115ecb88f219ca010889f"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1568732860.204
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1568732860.203,
+            "write_ts": 1568732860.204
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1574179740_1574222258.json
+++ b/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1574179740_1574222258.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5dd41fbd22ab29840bc899da"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1574179740.606
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1574179740.605,
+            "write_ts": 1574179740.606
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1574266220_1574309059.json
+++ b/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1574266220_1574309059.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5dd5714922ab29840bca8daf"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1574266220.955
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1574266220.954,
+            "write_ts": 1574266220.955
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1575389700_1575432907.json
+++ b/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1575389700_1575432907.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5de694c322ab29840bd102ba"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1575389700.998
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1575389700.997,
+            "write_ts": 1575389700.998
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1575908031_1575951192.json
+++ b/bin/data/ucb-sdb-android-4/train_bus_ebike_mtv_ucb/statemachine~transition/1575908031_1575951192.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5dee863d22ab29840bd4bf70"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1575908031.857
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1575908031.856,
+            "write_ts": 1575908031.857
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/unimodal_trip_car_bike_mtv_la/statemachine~transition/1564274294_1564282431.json
+++ b/bin/data/ucb-sdb-android-4/unimodal_trip_car_bike_mtv_la/statemachine~transition/1564274294_1564282431.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3cf3d4b88f219ca0a5866a"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564274294.79
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1564274294.789,
+            "write_ts": 1564274294.79
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/unimodal_trip_car_bike_mtv_la/statemachine~transition/1564351263_1564360072.json
+++ b/bin/data/ucb-sdb-android-4/unimodal_trip_car_bike_mtv_la/statemachine~transition/1564351263_1564360072.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d3e3738b88f219ca0a91029"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1564351264.073
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1564351264.072,
+            "write_ts": 1564351264.073
+        }
+    }
+]

--- a/bin/data/ucb-sdb-android-4/unimodal_trip_car_bike_mtv_la/statemachine~transition/1567288647_1567297375.json
+++ b/bin/data/ucb-sdb-android-4/unimodal_trip_car_bike_mtv_la/statemachine~transition/1567288647_1567297375.json
@@ -1,1 +1,24 @@
-[]
+[
+    {
+        "_id": {
+            "$oid": "5d6aee18b88f219ca0ebef63"
+        },
+        "metadata": {
+            "key": "statemachine/transition",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1567288647.517
+        },
+        "user_id": {
+            "$uuid": "4e5565f7316740e4a9f1b558ad9cffd5"
+        },
+        "data": {
+            "currState": "local.state.tracking_stopped",
+            "transition": "local.transition.stop_tracking",
+            "ts": 1567288647.516,
+            "write_ts": 1567288647.517
+        }
+    }
+]


### PR DESCRIPTION
After updating the specs to use E_BIKE instead of BICYCLING https://github.com/MobilityNet/mobilitynet-analysis-scripts/commit/43bb437fb981801fee0f123a21d053f9bc95939f https://github.com/MobilityNet/mobilitynet-analysis-scripts/commit/edbc4483b18194d5a6b70600fed54ca371a3ef3a I reloaded the data into a local database using `spec_creation/upload_validated_spec.py` and took a new mongodump snapshot

On re-downloading (`bin/dump_data_to_file.py`), the $oid and the write timestamps changed. But we also got a new transition in the timeline.
I restored to the older database snapshot, and the transitions were still downloaded

This is likely due to the restructuring of the dump script, in the commits below https://github.com/MobilityNet/mobilitynet-analysis-scripts/commit/be37dde875e0735cc940fcc9ff345c4b3c1c1bce https://github.com/MobilityNet/mobilitynet-analysis-scripts/commit/e78da4f83c6d82cd417e49edccf81b95da11b93f https://github.com/MobilityNet/mobilitynet-analysis-scripts/commit/dd6ba0f14c4e3893f51fce27c999fdc3726cf51e https://github.com/MobilityNet/mobilitynet-analysis-scripts/commit/f4f48c3343c1a74c3821f5a14ceac3f4fef4a05b I did not re-download raw data after the dump script changes.

I verified that the new transition did not change the outputs Checking these in to make the csv files snapshot consistent with the mongodump snapshot